### PR TITLE
Update Supervisely SDK to 6.73.564

### DIFF
--- a/config.json
+++ b/config.json
@@ -3,7 +3,7 @@
   "type": "app",
   "categories": ["images", "project management", "data operations"],
   "description": "Merge selected datasets with images or videos into a single one",
-  "docker_image": "supervisely/data-operations:6.73.158",
+  "docker_image": "supervisely/data-operations:6.73.564",
   "instance_version": "6.10.0",
   "main_script": "src/merge_datasets.py",
   "gui_template": "src/gui.html",

--- a/config.json
+++ b/config.json
@@ -1,9 +1,13 @@
 {
   "name": "Merge datasets",
   "type": "app",
-  "categories": ["images", "project management", "data operations"],
+  "categories": [
+    "images",
+    "project management",
+    "data operations"
+  ],
   "description": "Merge selected datasets with images or videos into a single one",
-  "docker_image": "supervisely/data-operations:6.73.564",
+  "docker_image": "supervisely/base-py-sdk-hardened:6.73.564",
   "instance_version": "6.15.60",
   "main_script": "src/merge_datasets.py",
   "gui_template": "src/gui.html",
@@ -11,7 +15,10 @@
   "icon": "https://i.imgur.com/DG3URUW.png",
   "icon_background": "#FFFFFF",
   "context_menu": {
-    "target": ["images_project", "videos_project"]
+    "target": [
+      "images_project",
+      "videos_project"
+    ]
   },
   "poster": "https://user-images.githubusercontent.com/48245050/182392835-74ef1899-fde8-459a-a628-b5ab5ed35210.png"
 }

--- a/config.json
+++ b/config.json
@@ -4,7 +4,7 @@
   "categories": ["images", "project management", "data operations"],
   "description": "Merge selected datasets with images or videos into a single one",
   "docker_image": "supervisely/data-operations:6.73.564",
-  "instance_version": "6.10.0",
+  "instance_version": "6.15.60",
   "main_script": "src/merge_datasets.py",
   "gui_template": "src/gui.html",
   "task_location": "workspace_tasks",

--- a/config.json
+++ b/config.json
@@ -7,7 +7,7 @@
     "data operations"
   ],
   "description": "Merge selected datasets with images or videos into a single one",
-  "docker_image": "supervisely/base-py-sdk-hardened:6.73.564",
+  "docker_image": "supervisely/base-py-sdk:6.73.564",
   "instance_version": "6.15.60",
   "main_script": "src/merge_datasets.py",
   "gui_template": "src/gui.html",

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,1 +1,1 @@
-supervisely==6.73.158
+supervisely==6.73.564


### PR DESCRIPTION
Updates default Supervisely Docker apps to Supervisely SDK `6.73.564`.

- Updates `docker_image` tags for default Supervisely images.
- Updates Supervisely SDK references in requirements and Dockerfiles.
- Does not release applications.

Validation: generated ecosystem inventory report.
